### PR TITLE
Update to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["geohash", "gis", "geography"]
 repository = "https://github.com/georust/geohash.rs"
 readme = "README.md"
 documentation = "https://docs.rs/geohash/"
+edition = "2018"
 
 [dependencies]
 geo-types = "0.4.2"

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,5 +1,5 @@
-use neighbors::Direction;
-use {Coordinate, GeohashError, Neighbors, Rect};
+use crate::neighbors::Direction;
+use crate::{Coordinate, GeohashError, Neighbors, Rect};
 
 use failure::Error;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use Coordinate;
+use crate::Coordinate;
 
 #[derive(Debug, Fail)]
 pub enum GeohashError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ mod core;
 mod error;
 mod neighbors;
 
-pub use core::{decode, decode_bbox, encode, neighbor, neighbors};
-pub use error::GeohashError;
+pub use crate::core::{decode, decode_bbox, encode, neighbor, neighbors};
+pub use crate::error::GeohashError;
+pub use crate::neighbors::{Direction, Neighbors};
 pub use geo_types::{Coordinate, Rect};
-pub use neighbors::{Direction, Neighbors};


### PR DESCRIPTION
Migrate crate to 2018 edition, reference issue #32. 