### PR TITLE
Remove deprecated failure as dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 
 [dependencies]
 geo-types = "0.6.0"
-failure = "0.1.2"
 
 [dev-dependencies]
 num-traits = "0.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,27 @@
+use std::error::Error;
+use std::fmt;
+
 use crate::Coordinate;
 
-#[derive(Debug, Fail)]
+#[derive(Debug)]
 pub enum GeohashError {
-    #[fail(display = "invalid hash character: {}", character)]
-    InvalidHashCharacter { character: char },
-    #[fail(display = "invalid coordinate range: {:?}", c)]
-    InvalidCoordinateRange { c: Coordinate<f64> },
+    InvalidHashCharacter(char),
+    InvalidCoordinateRange(Coordinate<f64>),
+}
+
+impl fmt::Display for GeohashError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GeohashError::InvalidHashCharacter(c) => write!(f, "invalid hash character: {}", c),
+            GeohashError::InvalidCoordinateRange(c) => {
+                write!(f, "invalid coordinate range: {:?}", c)
+            }
+        }
+    }
+}
+
+impl Error for GeohashError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,8 +20,4 @@ impl fmt::Display for GeohashError {
     }
 }
 
-impl Error for GeohashError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        None
-    }
-}
+impl Error for GeohashError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,6 @@
 extern crate geo_types;
 #[cfg(test)]
 extern crate num_traits;
-#[macro_use]
-extern crate failure;
 
 mod core;
 mod error;


### PR DESCRIPTION
Because our error type is still relatively easy to maintain, I'm removing failure as a dependency. This is a breaking change that to be released in next 0.x version.

