### PR TITLE
replace deprecated Coordinate to Coord

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,5 +1,5 @@
 use crate::neighbors::Direction;
-use crate::{Coordinate, GeohashError, Neighbors, Rect};
+use crate::{Coord, GeohashError, Neighbors, Rect};
 use libm::ldexp;
 
 // the alphabet for the base32 encoding used in geohashing
@@ -69,7 +69,7 @@ fn deinterleave(x: u64) -> (u32, u32) {
 /// Encoding a coordinate to a length five geohash:
 ///
 /// ```rust
-/// let coord = geohash::Coordinate { x: -120.6623, y: 35.3003 };
+/// let coord = geohash::Coord { x: -120.6623, y: 35.3003 };
 ///
 /// let geohash_string = geohash::encode(coord, 5).expect("Invalid coordinate");
 ///
@@ -79,13 +79,13 @@ fn deinterleave(x: u64) -> (u32, u32) {
 /// Encoding a coordinate to a length ten geohash:
 ///
 /// ```rust
-/// let coord = geohash::Coordinate { x: -120.6623, y: 35.3003 };
+/// let coord = geohash::Coord { x: -120.6623, y: 35.3003 };
 ///
 /// let geohash_string = geohash::encode(coord, 10).expect("Invalid coordinate");
 ///
 /// assert_eq!(geohash_string, "9q60y60rhs");
 /// ```
-pub fn encode(c: Coordinate<f64>, len: usize) -> Result<String, GeohashError> {
+pub fn encode(c: Coord<f64>, len: usize) -> Result<String, GeohashError> {
     let max_lat = 90f64;
     let min_lat = -90f64;
     let max_lon = 180f64;
@@ -181,8 +181,8 @@ fn bbox_int_with_precision(hash: u64, bits: u32) -> Rect<f64> {
     let (lat_err, long_err) = error_with_precision(bits);
 
     Rect::new(
-        Coordinate { x: long, y: lat },
-        Coordinate {
+        Coord { x: long, y: lat },
+        Coord {
             x: long + long_err,
             y: lat + lat_err,
         },
@@ -204,7 +204,7 @@ fn bbox_int_with_precision(hash: u64, bits: u32) -> Rect<f64> {
 /// assert_eq!(
 ///     decoded,
 ///     (
-///         geohash::Coordinate {
+///         geohash::Coord {
 ///             x: -120.65185546875,
 ///             y: 35.31005859375,
 ///         },
@@ -224,7 +224,7 @@ fn bbox_int_with_precision(hash: u64, bits: u32) -> Rect<f64> {
 /// assert_eq!(
 ///     decoded,
 ///     (
-///         geohash::Coordinate {
+///         geohash::Coord {
 ///             x: -120.66229999065399,
 ///             y: 35.300298035144806,
 ///         },
@@ -233,12 +233,12 @@ fn bbox_int_with_precision(hash: u64, bits: u32) -> Rect<f64> {
 ///     ),
 /// );
 /// ```
-pub fn decode(hash_str: &str) -> Result<(Coordinate<f64>, f64, f64), GeohashError> {
+pub fn decode(hash_str: &str) -> Result<(Coord<f64>, f64, f64), GeohashError> {
     let rect = decode_bbox(hash_str)?;
     let c0 = rect.min();
     let c1 = rect.max();
     Ok((
-        Coordinate {
+        Coord {
             x: (c0.x + c1.x) / 2f64,
             y: (c0.y + c1.y) / 2f64,
         },
@@ -264,7 +264,7 @@ pub fn decode(hash_str: &str) -> Result<(Coordinate<f64>, f64, f64), GeohashErro
 pub fn neighbor(hash_str: &str, direction: Direction) -> Result<String, GeohashError> {
     let (coord, lon_err, lat_err) = decode(hash_str)?;
     let (dlat, dlng) = direction.to_tuple();
-    let neighbor_coord = Coordinate {
+    let neighbor_coord = Coord {
         x: coord.x + 2f64 * lon_err.abs() * dlng,
         y: coord.y + 2f64 * lat_err.abs() * dlat,
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,12 @@
 use std::error::Error;
 use std::fmt;
 
-use crate::Coordinate;
+use crate::Coord;
 
 #[derive(Debug)]
 pub enum GeohashError {
     InvalidHashCharacter(char),
-    InvalidCoordinateRange(Coordinate<f64>),
+    InvalidCoordinateRange(Coord<f64>),
     InvalidLength(usize),
     InvalidHash(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,11 @@
 //!
 //! use std::error::Error;
 //!
-//! use geohash::{encode, decode, neighbor, Direction, Coordinate};
+//! use geohash::{encode, decode, neighbor, Direction, Coord};
 //!
 //! fn main() -> Result<(), Box<Error>> {
 //!   // encode a coordinate
-//!   let c = Coordinate { x: 112.5584f64, y: 37.8324f64 };
+//!   let c = Coord { x: 112.5584f64, y: 37.8324f64 };
 //!   println!("encoding 37.8324, 112.5584: {}", encode(c, 9usize)?);
 //!
 //!   // decode a geohash
@@ -42,4 +42,4 @@ mod neighbors;
 pub use crate::core::{decode, decode_bbox, encode, neighbor, neighbors};
 pub use crate::error::GeohashError;
 pub use crate::neighbors::{Direction, Neighbors};
-pub use geo_types::{Coordinate, Rect};
+pub use geo_types::{Coord, Rect};

--- a/tests/base.rs
+++ b/tests/base.rs
@@ -1,7 +1,7 @@
 extern crate geo_types;
 extern crate geohash;
 
-use geohash::{decode, encode, neighbors, Coordinate};
+use geohash::{decode, encode, neighbors, Coord};
 
 use csv;
 use serde::Deserialize;
@@ -22,7 +22,7 @@ fn test_encode() {
     let mut iter = rdr.deserialize();
     while let Some(result) = iter.next() {
         let record: TestCase = result.expect("Unable to deserialize record");
-        let c = Coordinate {
+        let c = Coord {
             x: record.long,
             y: record.lat,
         };
@@ -31,35 +31,35 @@ fn test_encode() {
     // check that errors are thrown appropriately
 
     // should throw an error because the length is greater than 12
-    let c1 = Coordinate {
+    let c1 = Coord {
         x: 117f64,
         y: 32f64,
     };
     assert!(encode(c1, 13).is_err());
 
     // should throw an error because the longitude is out of range
-    let c2 = Coordinate {
+    let c2 = Coord {
         x: 190f64,
         y: -80f64,
     };
     assert!(encode(c2, 3usize).is_err());
 
     // should throw an error because the latitude is out of range
-    let c3 = Coordinate {
+    let c3 = Coord {
         x: 100f64,
         y: -100f64,
     };
     assert!(encode(c3, 3usize).is_err());
 
     // should throw an error because the longitude is NAN
-    let c4 = Coordinate {
+    let c4 = Coord {
         x: f64::NAN,
         y: 50f64,
     };
     assert!(encode(c4, 4usize).is_err());
 
     // should throw an error because the latitude is NAN
-    let c5 = Coordinate {
+    let c5 = Coord {
         x: 100f64,
         y: f64::NAN,
     };


### PR DESCRIPTION
**Summary**
Replace deprecated `Coordinate` to `Coord`.