### PR TITLE
Fix neighbors of boundary cells

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -298,8 +298,8 @@ pub fn neighbor(hash_str: &str, direction: Direction) -> Result<String, GeohashE
     let (coord, lon_err, lat_err) = decode(hash_str)?;
     let (dlat, dlng) = direction.to_tuple();
     let neighbor_coord = Coord {
-        x: coord.x + 2f64 * lon_err.abs() * dlng,
-        y: coord.y + 2f64 * lat_err.abs() * dlat,
+        x: ((coord.x + 2f64 * lon_err.abs() * dlng) + 180.0).rem_euclid(360.0) - 180.0,
+        y: ((coord.y + 2f64 * lat_err.abs() * dlat) + 90.0).rem_euclid(180.0) - 90.0,
     };
     encode(neighbor_coord, hash_str.len())
 }

--- a/tests/base.rs
+++ b/tests/base.rs
@@ -118,6 +118,16 @@ fn test_neighbor() {
     assert_eq!(ns.nw, "ww8p1r4mz");
     assert_eq!(ns.n, "ww8p1r4tb");
     assert_eq!(ns.ne, "ww8p1r4tc");
+
+    let ns = neighbors("2hb").unwrap();
+    assert_eq!(ns.sw, "rux");
+    assert_eq!(ns.s, "2h8");
+    assert_eq!(ns.se, "2h9");
+    assert_eq!(ns.w, "ruz");
+    assert_eq!(ns.e, "2hc");
+    assert_eq!(ns.nw, "rvp");
+    assert_eq!(ns.n, "2j0");
+    assert_eq!(ns.ne, "2j1");
 }
 
 #[test]


### PR DESCRIPTION
This is a fix for the issue described in Issue #48. Test added for previously failing boundary case. 