### PR TITLE
Fix typo in direction enum comment for East

### DIFF
--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -16,7 +16,7 @@ pub enum Direction {
     N,
     /// North-east
     NE,
-    /// Eeast
+    /// East
     E,
     /// South-east
     SE,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
Fixing a small typo - from `Eeast` to `East` in a comment