### PR TITLE
Add `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "geohash"
 version = "0.13.1"
-authors = ["Ning Sun <sunng@about.me>"]
+authors = [ "Ning Sun <sunng@about.me>" ]
 description = "Geohash implementation for Rust."
 license = "MIT/Apache-2.0"
 keywords = ["geohash", "gis", "geography"]
-categories = ["science::geo"]
+categories = [ "science::geo" ]
 repository = "https://github.com/georust/geohash.rs"
 readme = "README.md"
 documentation = "https://docs.rs/geohash/"
@@ -16,10 +16,10 @@ default = ["std"]
 std = ["geo-types/std"]
 
 [dependencies]
-geo-types = { version = ">=0.6.0, <0.8.0", default-features = false }
+geo-types = {version = ">=0.6.0, <0.8.0", default-features = false}
 libm = "0.2.6"
 
 [dev-dependencies]
 csv = "1.2"
-num-traits = { version = "0.2", default-features = false, features = ["libm"] }
-serde = { version = "1", features = ["derive"] }
+num-traits = {version = "0.2", default-features = false, features = ["libm"]}
+serde = {version = "1", features = ["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,25 @@
 [package]
 name = "geohash"
 version = "0.13.1"
-authors = [ "Ning Sun <sunng@about.me>" ]
+authors = ["Ning Sun <sunng@about.me>"]
 description = "Geohash implementation for Rust."
 license = "MIT/Apache-2.0"
 keywords = ["geohash", "gis", "geography"]
-categories = [ "science::geo" ]
+categories = ["science::geo"]
 repository = "https://github.com/georust/geohash.rs"
 readme = "README.md"
 documentation = "https://docs.rs/geohash/"
 edition = "2018"
 
+[features]
+default = ["std"]
+std = ["geo-types/std"]
+
 [dependencies]
-geo-types = ">=0.6.0, <0.8.0"
+geo-types = { version = ">=0.6.0, <0.8.0", default-features = false }
 libm = "0.2.6"
 
 [dev-dependencies]
 csv = "1.2"
-num-traits = "0.2"
-serde = {version = "1", features = ["derive"]}
+num-traits = { version = "0.2", default-features = false, features = ["libm"] }
+serde = { version = "1", features = ["derive"] }

--- a/src/core.rs
+++ b/src/core.rs
@@ -312,8 +312,8 @@ pub fn neighbor(hash_str: &str, direction: Direction) -> Result<String, GeohashE
     let (dlat, dlng) = direction.to_tuple();
     #[cfg(not(feature = "std"))]
     let neighbor_coord = Coord {
-        x: rem_euclid(coord.x + 2f64 * lon_err.abs() * dlng, 360.0) - 180.0,
-        y: rem_euclid(coord.y + 2f64 * lat_err.abs() * dlat, 180.0) - 90.0,
+        x: rem_euclid((coord.x + 2f64 * lon_err.abs() * dlng) + 180.0, 360.0) - 180.0,
+        y: rem_euclid((coord.y + 2f64 * lat_err.abs() * dlat) + 90.0, 180.0) - 90.0,
     };
     #[cfg(feature = "std")]
     let neighbor_coord = Coord {

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,5 +1,6 @@
 use crate::neighbors::Direction;
 use crate::{Coord, GeohashError, Neighbors, Rect};
+use alloc::string::{String, ToString};
 use libm::ldexp;
 
 // the alphabet for the base32 encoding used in geohashing
@@ -222,6 +223,18 @@ fn bbox_int_with_precision(hash: u64, bits: u32) -> Rect<f64> {
     )
 }
 
+#[cfg(not(feature = "std"))]
+// `f64::rem_euclid` is unavailable in no-std builds, so keep a small
+// equivalent helper for wrapping coordinates.
+fn rem_euclid(x: f64, rhs: f64) -> f64 {
+    let r = x % rhs;
+    if r < 0.0 {
+        r + rhs.abs()
+    } else {
+        r
+    }
+}
+
 /// Decode a geohash into a coordinate with some longitude/latitude error. The
 /// return value is `(<coordinate>, <longitude error>, <latitude error>)`.
 ///
@@ -297,6 +310,12 @@ pub fn decode(hash_str: &str) -> Result<(Coord<f64>, f64, f64), GeohashError> {
 pub fn neighbor(hash_str: &str, direction: Direction) -> Result<String, GeohashError> {
     let (coord, lon_err, lat_err) = decode(hash_str)?;
     let (dlat, dlng) = direction.to_tuple();
+    #[cfg(not(feature = "std"))]
+    let neighbor_coord = Coord {
+        x: rem_euclid(coord.x + 2f64 * lon_err.abs() * dlng, 360.0) - 180.0,
+        y: rem_euclid(coord.y + 2f64 * lat_err.abs() * dlat, 180.0) - 90.0,
+    };
+    #[cfg(feature = "std")]
     let neighbor_coord = Coord {
         x: ((coord.x + 2f64 * lon_err.abs() * dlng) + 180.0).rem_euclid(360.0) - 180.0,
         y: ((coord.y + 2f64 * lat_err.abs() * dlat) + 90.0).rem_euclid(180.0) - 90.0,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,8 @@
+use alloc::string::String;
+use core::fmt;
+
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt;
 
 use crate::Coord;
 
@@ -28,4 +31,5 @@ impl fmt::Display for GeohashError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for GeohashError {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,5 @@
 use alloc::string::String;
-use core::fmt;
-
-#[cfg(feature = "std")]
-use std::error::Error;
+use core::{error::Error, fmt};
 
 use crate::Coord;
 
@@ -31,5 +28,4 @@ impl fmt::Display for GeohashError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for GeohashError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/geohash/")]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! # Geohash
 //!
@@ -30,6 +31,8 @@
 //! }
 //! ```
 //!
+
+extern crate alloc;
 
 mod core;
 mod error;

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Neighbors {
     pub sw: String,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

I needed to use this crate in an embedded project where `std` is not available. With only minor changes it now supports no_std environments while remaining completely backwards compatible.

I added an `std` feature (enabled by default) that gates the `std` only types. The only non-trivial change was `f64::rem_euclid`, which is a std-only method on stable Rust, I added a small fallback implementation that is only compiled in when std is disabled.

I would add an entry to the changelog, but it doesn't seem that it exists. Let me know if there are any changes you would like me to do. 
