### PR TITLE
ci: improve ci to cover no_std

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,12 @@ jobs:
           - build: nightly
             rust: nightly
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy,rustfmt
       - run: cargo fmt -- --check
-      - run: cargo install cargo-all-features
-      - run: cargo build-all-features
-      - run: cargo test-all-features
-      - run: cargo clippy --all-features
+      - run: cargo test
+      - run: cargo test --no-default-features
+      - run: cargo clippy


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
