### PR TITLE
Fix maximum coordinate encoding wrapping to the opposite corner

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -99,6 +99,19 @@ fn deinterleave(x: u64) -> (u32, u32) {
     (squash(x), squash(x >> 1))
 }
 
+// Reads the top 32 significand bits of a coordinate mapped into [1, 2]. At the
+// maximum coordinate (and its f64 predecessor) the value rounds to exactly 2.0,
+// whose significand bits are zero, which would wrap the top edge onto the bottom
+// cell (#52); clamp anything that reaches the top of the window to the top cell.
+#[inline]
+fn quantize(v: f64) -> u32 {
+    if v >= 2.0 {
+        u32::MAX
+    } else {
+        (v.to_bits() >> 20) as u32
+    }
+}
+
 /// Encode a coordinate to a geohash with length `len`.
 ///
 /// ### Examples
@@ -167,9 +180,9 @@ pub fn encode_iter(c: Coord<f64>) -> Result<impl Iterator<Item = char>, GeohashE
 
     // divides the latitude by 180, then adds 1.5 to give a value between 1 and 2
     // then we take the first 32 bits of the significand as a u32
-    let lat32 = ((c.y * 0.005555555555555556 + 1.5).to_bits() >> 20) as u32;
+    let lat32 = quantize(c.y * 0.005555555555555556 + 1.5);
     // same as latitude, but a division by 360 instead of 180
-    let lon32 = ((c.x * 0.002777777777777778 + 1.5).to_bits() >> 20) as u32;
+    let lon32 = quantize(c.x * 0.002777777777777778 + 1.5);
 
     let mut interleaved_int = interleave(lat32, lon32);
 

--- a/tests/base.rs
+++ b/tests/base.rs
@@ -61,6 +61,67 @@ fn test_encode() {
     assert!(encode(c5, 4usize).is_err());
 }
 
+#[test]
+fn test_encode_max_boundary() {
+    // The inclusive maximum coordinates used to wrap onto the opposite corner
+    // (#52). They must map to the top cell instead; reference strings come from
+    // the standard base32 bisection.
+    let cases = [
+        (90.0, 180.0, "zzzzzzzzzzzz"),
+        (90.0, 0.0, "upbpbpbpbpbp"),
+        (0.0, 180.0, "xbpbpbpbpbpb"),
+        (90.0, -180.0, "bpbpbpbpbpbp"),
+        (-90.0, 180.0, "pbpbpbpbpbpb"),
+        (-90.0, -180.0, "000000000000"),
+    ];
+    for (lat, lon, expected) in cases {
+        assert_eq!(encode(Coord { x: lon, y: lat }, 12).unwrap(), expected);
+    }
+
+    // The f64 predecessor of the max rounds to the same value and must also land
+    // in the top cell rather than wrap to "000...".
+    let pred = |x: f64| f64::from_bits(x.to_bits() - 1);
+    assert_eq!(
+        encode(
+            Coord {
+                x: 180.0,
+                y: pred(90.0),
+            },
+            12
+        )
+        .unwrap(),
+        "zzzzzzzzzzzz"
+    );
+    assert_eq!(
+        encode(
+            Coord {
+                x: pred(180.0),
+                y: 90.0,
+            },
+            12
+        )
+        .unwrap(),
+        "zzzzzzzzzzzz"
+    );
+
+    // The corner round-trips back near (90, 180), not (-90, -180).
+    let (corner, _, _) = decode("zzzzzzzzzzzz").unwrap();
+    assert!(corner.x > 179.9 && corner.y > 89.9, "{:?}", corner);
+
+    // Interior encoding is unchanged.
+    assert_eq!(
+        encode(
+            Coord {
+                x: -120.6623,
+                y: 35.3003
+            },
+            12
+        )
+        .unwrap(),
+        "9q60y60rhsgg"
+    );
+}
+
 fn compare_within(a: f64, b: f64, diff: f64) {
     assert!(
         (a - b).abs() < diff,


### PR DESCRIPTION
Fixes #52.

`encode`/`encode_iter` accept the inclusive maximum coordinates but encode them to the diagonally opposite corner:

```rust
let hash = geohash::encode(geohash::Coord { x: 180.0, y: 90.0 }, 5).unwrap();
assert_eq!(hash, "00000");            // it should be "zzzzz"
let (c, _, _) = geohash::decode(&hash).unwrap();
// c == (x: -180.0, y: -90.0) -- the SW corner, opposite side of the planet
```

The quantization maps a coordinate into `[1, 2]` and reads the top significand bits via `(v.to_bits() >> 20) as u32`. At the maximum the mapped value is exactly `2.0`: the exponent has ticked over to the next binade and the significand bits are all zero, so the top edge collapses onto the same all-zero cell as the minimum. The interior is exact — only the `lat == 90` / `lon == 180` edges wrap.

The fix clamps a mapped value that reaches the top of the window to the all-ones top cell, so `encode(90, 180)` yields `"zzz…"` and round-trips back near `(90, 180)`, matching the standard base32 bisection. The guard is on the mapped value (`>= 2.0`) rather than on `coord == max`: the f64 predecessor of each maximum (`89.99999999999999`, `179.99999999999997`) rounds to the same `2.0` and wrapped as well, so an equality check on the input would miss it.

Interior encoding is unchanged (the `testcases.csv` corpus still passes). `test_encode_max_boundary` covers the grid corners, the mixed max/interior edges, the f64-predecessor cases, and the decode round-trip; strings were checked against an independent iterative reference encoder.
